### PR TITLE
ci: migrate npm auth to OIDC trusted publisher

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,7 @@ jobs:
       contents: write # Needed to create releases and tags
       issues: write   # Needed to comment on issues
       pull-requests: write # Needed to comment on pull requests
+      id-token: write # Needed for npm OIDC trusted publisher
 
     steps:
       # Step 1: Checkout the repository
@@ -31,7 +32,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22' # Use Node.js version 22
+          node-version: '24' # Use Node.js version 24
           registry-url: 'https://registry.npmjs.org' # Set the npm registry URL
 
       # Step 3: Install pnpm package manager
@@ -59,6 +60,5 @@ jobs:
       # Step 8: Run semantic-release to handle versioning, changelog, and publishing
       - name: Publish to npm
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # Token for npm authentication
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Token for GitHub authentication
         run: pnpx semantic-release # Execute semantic-release to automate the release process


### PR DESCRIPTION
Migrate from `NODE_AUTH_TOKEN` secret to npm's OIDC trusted publisher for authentication.

Changes:
- Added `id-token: write` permission (required for OIDC token exchange)
- Removed `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` — `actions/setup-node` now handles auth via OIDC
- Bumped `node-version` from `22` → `24` to match package `engines` requirement

After merge, CI will publish v2.0.0 via semantic-release using the trusted publisher configured on npm.