### PR TITLE
ci: remove semantic-git and changelog plugins

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,32 +6,16 @@
       "prerelease": true
     }
   ],
-    "plugins": [
-      "@semantic-release/commit-analyzer",
-      "@semantic-release/release-notes-generator",
-      "@semantic-release/npm",
-      [
-        "@semantic-release/github",
-        {
-          "successComment": false,
-          "failComment": false
-        }
-      ],
-      [
-        "@semantic-release/changelog",
-        {
-          "changelogFile": "CHANGELOG.md"
-        }
-      ],
-      [
-        "@semantic-release/git",
-        {
-          "assets": [
-            "package.json",
-            "CHANGELOG.md"
-          ],
-          "message": "chore(release): ${nextRelease.version} [skip ci]"
-        }
-      ]
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/npm",
+    [
+      "@semantic-release/github",
+      {
+        "successComment": false,
+        "failComment": false
+      }
     ]
+  ]
 }


### PR DESCRIPTION
Removes `@semantic-release/git` and `@semantic-release/changelog` from the release pipeline.

Reason: branch protection rules block direct pushes to master, which these plugins rely on for committing `package.json` version bumps and `CHANGELOG.md` updates.

npm publish and GitHub release creation still work via API (bypassing push restrictions). The version tag is pushed by `@semantic-release/github` via API, not git push.

This unblocks the v2.0.0 publish — semantic-release will re-run after merge and complete successfully.