### PR TITLE
feat: deploy MCP server to AWS Lambda via Serverless Framework v4 native mcp: property

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -1,0 +1,59 @@
+name: Deploy to AWS Lambda
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'serverless.yml'
+      - 'src/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/deploy-aws.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: aws-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy MCP Server to AWS
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      AWS_REGION: us-east-1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Setup pnpm
+        run: npm install -g pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build the project
+        run: pnpm build
+
+      - name: Run tests
+        run: pnpm test
+
+      - name: Deploy with Serverless Framework
+        env:
+          SERVERLESS_ACCESS_KEY: ${{ secrets.SERVERLESS_ACCESS_KEY }}
+          FREE_CURRENCY_API_KEY: ${{ secrets.FREE_CURRENCY_API_KEY }}
+        run: npx serverless@4 deploy

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,20 @@
 # Workflow name
 name: Publish to npm with Semantic Release
 
-# Trigger the workflow on pushes to the specified branches
+# Trigger the workflow on pushes to the specified branches. Path filters keep
+# infrastructure-only changes (serverless.yml, deploy-aws.yml) from releasing a
+# new npm version.
 on:
   push:
     branches:
       - master # Main branch for stable releases
       - next   # Branch for pre-releases
+    paths:
+      - 'src/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - '.releaserc.json'
+      - '.github/workflows/publish.yml'
 
 jobs:
   release:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,20 +1,22 @@
 # Workflow name
 name: Publish to npm with Semantic Release
 
-# Trigger the workflow on pushes to the specified branches. Path filters keep
-# infrastructure-only changes (serverless.yml, deploy-aws.yml) from releasing a
-# new npm version.
+# DISABLED for serverless CI/CD testing — automatic npm publishing is paused.
+# Trigger manually with "Run workflow" when ready to release again, then restore
+# the `push` trigger below.
 on:
-  push:
-    branches:
-      - master # Main branch for stable releases
-      - next   # Branch for pre-releases
-    paths:
-      - 'src/**'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - '.releaserc.json'
-      - '.github/workflows/publish.yml'
+  workflow_dispatch:
+
+  # push:
+  #   branches:
+  #     - master # Main branch for stable releases
+  #     - next   # Branch for pre-releases
+  #   paths:
+  #     - 'src/**'
+  #     - 'package.json'
+  #     - 'pnpm-lock.yaml'
+  #     - '.releaserc.json'
+  #     - '.github/workflows/publish.yml'
 
 jobs:
   release:

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ pnpm-debug.log*
 
 # Test
 coverage/
+
+# Serverless Framework
+.serverless/
+serverless-mcp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,14 +15,15 @@ pnpm inspector-http    # build + start http server on :3000 + launch MCP Inspect
 ```
 
 ## Architecture
-- **Entry**: `src/index.ts` → `src/server.ts` → `src/utils/registrations.ts`
+- **Entry**: `src/index.ts` → `src/server.ts` → `src/utils/registrations.ts`; serverless: `src/serverless.ts` (default-export of `createMcpHandler`)
 - **MCP SDK v2 `^2.0.0`**: Uses `@modelcontextprotocol/server` (`McpServer`, `createMcpHandler`) + `@modelcontextprotocol/node` (`toNodeHandler`) — NOT the deprecated `@modelcontextprotocol/sdk`
-- **Factory-based**: `serveStdio(factory)` / `createMcpHandler(factory)` build a fresh `McpServer` per request (stateless — no initialize handshake, no `Mcp-Session-Id`)
-- **2 transports**: `TRANSPORT=stdio` (default when unset), `http` (SSE transport removed in v2)
+- **Factory-based**: `serveStdio(factory)` / `createMcpHandler(factory)` build a fresh `McpServer` per request (stateless — no initialize handshake, no `Mcp-Session-Id`). The factory lives in `src/factory.ts` (`createFactory(logger)`) and is shared by stdio, HTTP, and Lambda entries.
+- **3 transports**: `TRANSPORT=stdio` (default when unset), `http`, and the Serverless Framework v4 Lambda entry (`src/serverless.ts`)
 - **1 tool**: `convert-currency` — `z.object({ fromCurrency, toCurrency, amount, date? })`
 - **1 resource**: `list-currencies`
 - **1 prompt**: `currency-conversion-prompt`
 - **API**: https://freecurrencyapi.com (requires key)
+- **AWS deploy**: native `mcp:` property in root `serverless.yml` (`mcp.servers.currency-converter.server: dist/serverless.js`). Framework owns REST endpoint/streaming/packaging/Lambda entry. Config lives at repo root, NOT in `serverless/` (packaging ships the service directory's tree + `node_modules`; `server:` path is relative to `serverless.yml`).
 
 ## Critical gotchas
 - **dotenv v17**: `dotenv.config()` writes to stdout, breaking MCP stdio JSON-RPC. **Always** use `dotenv.config({ quiet: true })` in `src/server.ts:11`.
@@ -37,6 +38,9 @@ pnpm inspector-http    # build + start http server on :3000 + launch MCP Inspect
 - **pnpm-workspace.yaml**: `allowBuilds` must keep `@modelcontextprotocol/inspector: true` (its postinstall builds the CLI).
 - **stdio is the default transport**: `TRANSPORT` unset → stdio. Do **not** set `TRANSPORT` in `.env` — dotenv would override the default and force HTTP.
 - **MCP Inspector filters env**: its `StdioClientTransport` spawns the server with only `HOME/LOGNAME/PATH/SHELL/TERM/USER` + env configured in the UI. Any required env (e.g. `FREE_CURRENCY_API_KEY`) must be added in the Inspector's server config "Environment" panel; shell env vars like `TRANSPORT=stdio` are NOT inherited.
+- **Serverless MCP entry contract**: `dist/serverless.js` (from `src/serverless.ts`) must default-export the object `createMcpHandler()` returns — a web-standard `fetch` handler. Anything else fails at cold start naming the `server:` property.
+- **Serverless packaging**: classic zip ships the service directory tree + production `node_modules` (dev deps pruned; SDK + zod must stay in `dependencies`). `server:` path is relative to `serverless.yml`, so the config lives at repo root. Run `pnpm build` before `serverless deploy`.
+- **Lambda package excludes `.env`** via `package.patterns` so the API key never ships in the artifact.
 
 ## Tests
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ pnpm inspector-http    # build + start http server on :3000 + launch MCP Inspect
 - **1 resource**: `list-currencies`
 - **1 prompt**: `currency-conversion-prompt`
 - **API**: https://freecurrencyapi.com (requires key)
-- **AWS deploy**: native `mcp:` property in root `serverless.yml` (`mcp.servers.currency-converter.server: dist/serverless.js`). Framework owns REST endpoint/streaming/packaging/Lambda entry. Config lives at repo root, NOT in `serverless/` (packaging ships the service directory's tree + `node_modules`; `server:` path is relative to `serverless.yml`).
+- **AWS deploy**: native `mcp:` property in root `serverless.yml` (`mcp.servers.currency-converter.server: dist/serverless.mjs`). Framework owns REST endpoint/streaming/packaging/Lambda entry. Config lives at repo root, NOT in `serverless/`. The Lambda entry is esbuild-bundled into one self-contained file and `node_modules` is excluded from the package.
 
 ## Critical gotchas
 - **dotenv v17**: `dotenv.config()` writes to stdout, breaking MCP stdio JSON-RPC. **Always** use `dotenv.config({ quiet: true })` in `src/server.ts:11`.
@@ -38,8 +38,8 @@ pnpm inspector-http    # build + start http server on :3000 + launch MCP Inspect
 - **pnpm-workspace.yaml**: `allowBuilds` must keep `@modelcontextprotocol/inspector: true` (its postinstall builds the CLI).
 - **stdio is the default transport**: `TRANSPORT` unset → stdio. Do **not** set `TRANSPORT` in `.env` — dotenv would override the default and force HTTP.
 - **MCP Inspector filters env**: its `StdioClientTransport` spawns the server with only `HOME/LOGNAME/PATH/SHELL/TERM/USER` + env configured in the UI. Any required env (e.g. `FREE_CURRENCY_API_KEY`) must be added in the Inspector's server config "Environment" panel; shell env vars like `TRANSPORT=stdio` are NOT inherited.
-- **Serverless MCP entry contract**: `dist/serverless.js` (from `src/serverless.ts`) must default-export the object `createMcpHandler()` returns — a web-standard `fetch` handler. Anything else fails at cold start naming the `server:` property.
-- **Serverless packaging**: classic zip ships the service directory tree + production `node_modules` (dev deps pruned; SDK + zod must stay in `dependencies`). `server:` path is relative to `serverless.yml`, so the config lives at repo root. Run `pnpm build` before `serverless deploy`.
+- **Serverless MCP entry contract**: `dist/serverless.mjs` (from `src/serverless.ts`, esbuild-bundled by the `build` script) must default-export the object `createMcpHandler()` returns — a web-standard `fetch` handler. Anything else fails at cold start naming the `server:` property.
+- **Serverless packaging**: the entry is bundled into one self-contained `dist/serverless.mjs`, so `node_modules/**` is excluded via `package.patterns` — the Lambda package is ~1 MB. Without the bundle, pnpm's `node_modules/.pnpm` store (dev + prod) ships whole and the upload balloons to ~370 MB. Run `pnpm build` (which runs esbuild) before `serverless deploy`.
 - **Lambda package excludes `.env`** via `package.patterns` so the API key never ships in the artifact.
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -201,17 +201,19 @@ Using the npm module,
 
 The server can be deployed as a managed MCP server on AWS Lambda using the Serverless Framework v4's native `mcp:` property. The Framework owns the REST endpoint, response streaming, packaging, and the Lambda entry that bridges its streaming runtime to the server's web-standard `fetch` handler.
 
-The Lambda entry is `src/serverless.ts` (compiled to `dist/serverless.js`), declared in the root `serverless.yml`:
+The Lambda entry is `src/serverless.ts`, esbuild-bundled into a self-contained `dist/serverless.mjs` by `pnpm build`, and declared in the root `serverless.yml`:
 
 ```yml
 mcp:
   servers:
     currency-converter:
-      server: dist/serverless.js
+      server: dist/serverless.mjs
       timeout: 30
       environment:
         FREE_CURRENCY_API_KEY: ${env:FREE_CURRENCY_API_KEY}
 ```
+
+Because the entry is bundled, `node_modules` is excluded from the Lambda package (`package.patterns: ['!node_modules/**']`), keeping the upload at ~1 MB.
 
 The endpoint is public (no authorizer) and served at `https://<api-id>.execute-api.<region>.amazonaws.com/<stage>/currency-converter/mcp`.
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,44 @@ Using the npm module,
 }
 ```
 
+## Deploy to AWS (Serverless Framework)
+
+The server can be deployed as a managed MCP server on AWS Lambda using the Serverless Framework v4's native `mcp:` property. The Framework owns the REST endpoint, response streaming, packaging, and the Lambda entry that bridges its streaming runtime to the server's web-standard `fetch` handler.
+
+The Lambda entry is `src/serverless.ts` (compiled to `dist/serverless.js`), declared in the root `serverless.yml`:
+
+```yml
+mcp:
+  servers:
+    currency-converter:
+      server: dist/serverless.js
+      timeout: 30
+      environment:
+        FREE_CURRENCY_API_KEY: ${env:FREE_CURRENCY_API_KEY}
+```
+
+The endpoint is public (no authorizer) and served at `https://<api-id>.execute-api.<region>.amazonaws.com/<stage>/currency-converter/mcp`.
+
+### Prerequisites
+
+- A serverless.com account and an access key ([serverless.com](https://app.serverless.com))
+- An AWS IAM role that trusts GitHub Actions (OIDC) and can deploy CloudFormation stacks
+- GitHub repository secrets:
+  - `AWS_DEPLOY_ROLE_ARN` — ARN of the OIDC IAM role
+  - `SERVERLESS_ACCESS_KEY` — serverless.com access key
+  - `FREE_CURRENCY_API_KEY` — freecurrencyapi.com API key
+
+### Deploy from your machine
+
+```bash
+$ pnpm build
+$ SERVERLESS_ACCESS_KEY=xxx FREE_CURRENCY_API_KEY=xxx npx serverless@4 deploy
+```
+
+### Deploy from GitHub Actions
+
+Pushes to `master` that touch `serverless.yml`, `src/**`, or the dependency manifests trigger `.github/workflows/deploy-aws.yml`, which builds, tests, and deploys with `npx serverless@4 deploy`.
+
 ## License
 
 ISC License

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "alcorme-mcp-server": "./dist/index.js"
   },
   "scripts": {
-    "build": "tsc && node -e \"require('fs').chmodSync('dist/index.js', '755')\"",
+    "build": "tsc && node -e \"require('fs').chmodSync('dist/index.js', '755')\" && esbuild src/serverless.ts --bundle --platform=node --format=esm --outfile=dist/serverless.mjs",
     "build:watch": "tsc --watch",
     "build:dev": "tsx --watch src/index.ts",
     "mcp:stdio": "pnpm build && TRANSPORT=stdio node dist/index.js",
@@ -55,6 +55,7 @@
     "@types/express": "^5.0.6",
     "@types/node": "^26.2.0",
     "@vitest/coverage-v8": "^4.1.10",
+    "esbuild": "^0.28.1",
     "semantic-release": "^25.0.9",
     "tsx": "^4.23.12",
     "typescript": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.10
         version: 4.1.10(vitest@4.1.10)
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.2
       semantic-release:
         specifier: ^25.0.9
         version: 25.0.9(typescript@6.0.3)

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,26 +1,30 @@
 # Serverless Framework v4 native MCP deployment.
 #
-# `mcp.servers.currency-converter.server` points at the compiled Lambda entry
-# (src/serverless.ts -> dist/serverless.js), whose default export is what
-# `createMcpHandler()` returns — a web-standard fetch handler. The Framework
-# owns the REST endpoint, response streaming, packaging, and the Lambda entry
-# that bridges its streaming runtime to that handler.
+# `mcp.servers.currency-converter.server` points at the bundled Lambda entry
+# (src/serverless.ts bundled to dist/serverless.mjs by esbuild), whose default
+# export is what `createMcpHandler()` returns — a web-standard fetch handler.
+# The Framework owns the REST endpoint, response streaming, packaging, and the
+# Lambda entry that bridges its streaming runtime to that handler.
 service: mcp-currency-converter
 frameworkVersion: '4'
 
 provider:
   name: aws
-  region: ${env:AWS_REGION, 'us-east-1'}
+  region: ${env:AWS_REGION, 'us-west-2'}
   stage: ${opt:stage, 'prod'}
   runtime: nodejs24.x # MCP SDK requires Node.js 20 or newer
   # Regional endpoints keep a response stream alive through ~5 minutes of
   # silence (edge-optimized endpoints cut it at ~30s).
   endpointType: REGIONAL
 
-# Classic zip packaging ships dist/ + production node_modules. Exclude secrets
-# and build/test artifacts from the Lambda package.
+# The serverless entry is esbuild-bundled into a single self-contained
+# dist/serverless.mjs (see the `build` script in package.json), so the Lambda
+# package needs no node_modules. Exclude secrets and build/test artifacts.
 package:
   patterns:
+    - '!node_modules/**'
+    - '!.serverless/**'
+    - '!serverless-mcp/**'
     - '!.env'
     - '!.github/**'
     - '!coverage/**'
@@ -38,7 +42,7 @@ mcp:
     # The server name is the function key, the Lambda name suffix, and the URL
     # path segment: served at /currency-converter/mcp.
     currency-converter:
-      server: dist/serverless.js
+      server: dist/serverless.mjs
       timeout: 30
       environment:
         FREE_CURRENCY_API_KEY: ${env:FREE_CURRENCY_API_KEY}

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,0 +1,44 @@
+# Serverless Framework v4 native MCP deployment.
+#
+# `mcp.servers.currency-converter.server` points at the compiled Lambda entry
+# (src/serverless.ts -> dist/serverless.js), whose default export is what
+# `createMcpHandler()` returns — a web-standard fetch handler. The Framework
+# owns the REST endpoint, response streaming, packaging, and the Lambda entry
+# that bridges its streaming runtime to that handler.
+service: mcp-currency-converter
+frameworkVersion: '4'
+
+provider:
+  name: aws
+  region: ${env:AWS_REGION, 'us-east-1'}
+  stage: ${opt:stage, 'prod'}
+  runtime: nodejs24.x # MCP SDK requires Node.js 20 or newer
+  # Regional endpoints keep a response stream alive through ~5 minutes of
+  # silence (edge-optimized endpoints cut it at ~30s).
+  endpointType: REGIONAL
+
+# Classic zip packaging ships dist/ + production node_modules. Exclude secrets
+# and build/test artifacts from the Lambda package.
+package:
+  patterns:
+    - '!.env'
+    - '!.github/**'
+    - '!coverage/**'
+    - '!src/**'
+    - '!*.test.*'
+    - '!vitest.config.ts'
+    - '!tsconfig.json'
+    - '!pnpm-workspace.yaml'
+    - '!AGENTS.md'
+    - '!CHANGELOG.md'
+    - '!README.md'
+
+mcp:
+  servers:
+    # The server name is the function key, the Lambda name suffix, and the URL
+    # path segment: served at /currency-converter/mcp.
+    currency-converter:
+      server: dist/serverless.js
+      timeout: 30
+      environment:
+        FREE_CURRENCY_API_KEY: ${env:FREE_CURRENCY_API_KEY}

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,0 +1,40 @@
+import { McpServer } from '@modelcontextprotocol/server';
+import { PACKAGE_NAME, VERSION } from './utils/constants.js';
+import { Logger } from './utils/logger.js';
+import { registerPrompts, registerResources, registerTools } from './utils/registrations.js';
+
+/**
+ * Creates the MCP server factory shared by every entry point (stdio, HTTP,
+ * and the Serverless Framework v4 Lambda entry).
+ *
+ * The v2 SDK is factory-based: `serveStdio` and `createMcpHandler` invoke the
+ * returned closure to build a fresh `McpServer` per connection, capturing
+ * shared state (the logger) in the closure.
+ *
+ * @param logger The logger instance shared by all server instances
+ * @returns A factory that builds a fully registered `McpServer` per call
+ */
+export function createFactory(logger: Logger) {
+  return () => {
+    const server = new McpServer(
+      {
+        name: PACKAGE_NAME,
+        version: VERSION,
+      },
+      {
+        capabilities: {
+          resources: {},
+          tools: {},
+          prompts: {},
+        },
+      },
+    );
+
+    // Register tools, resources, and prompts to the server
+    registerTools(server, logger);
+    registerResources(server, logger);
+    registerPrompts(server, logger);
+
+    return server;
+  };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,10 +1,8 @@
-import { McpServer } from '@modelcontextprotocol/server';
 import { serveStdio } from '@modelcontextprotocol/server/stdio';
 import dotenv from 'dotenv';
-import { PACKAGE_NAME, VERSION } from './utils/constants.js';
+import { createFactory } from './factory.js';
 import { createHttpTransport } from './transport/httpTransport.js';
 import { Logger } from './utils/logger.js';
-import { registerPrompts, registerResources, registerTools } from './utils/registrations.js';
 
 // Load environment variables from .env file to configure the application
 dotenv.config({ quiet: true });
@@ -25,28 +23,7 @@ export function createMcpServer() {
 
   // Factory builds a fresh server per connection, capturing shared state
   // (logger) in a closure.
-  const factory = () => {
-    const server = new McpServer(
-      {
-        name: PACKAGE_NAME,
-        version: VERSION,
-      },
-      {
-        capabilities: {
-          resources: {},
-          tools: {},
-          prompts: {},
-        },
-      },
-    );
-
-    // Register tools, resources, and prompts to the server
-    registerTools(server, logger);
-    registerResources(server, logger);
-    registerPrompts(server, logger);
-
-    return server;
-  };
+  const factory = createFactory(logger);
 
   // Configure the transport layer based on the TRANSPORT environment variable.
   // Defaults to stdio when TRANSPORT is unset — the inspector and most MCP

--- a/src/serverless.test.ts
+++ b/src/serverless.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import handler from './serverless.js';
+
+describe('Serverless Framework v4 entry', () => {
+  it('default-exports a web-standard fetch handler', () => {
+    expect(handler).toBeDefined();
+    expect(typeof (handler as unknown as { fetch: unknown }).fetch).toBe('function');
+  });
+});

--- a/src/serverless.ts
+++ b/src/serverless.ts
@@ -1,0 +1,24 @@
+import { createMcpHandler } from '@modelcontextprotocol/server';
+import dotenv from 'dotenv';
+import { createFactory } from './factory.js';
+import { Logger } from './utils/logger.js';
+
+// Load environment variables from .env file to configure the application
+// (a no-op in Lambda, where they come from the function configuration).
+dotenv.config({ quiet: true });
+
+const logger = Logger.log();
+
+/**
+ * Serverless Framework v4 Lambda entry point.
+ *
+ * The Framework's `mcp:` property requires the module's default export to be
+ * the object `createMcpHandler` returns — a web-standard `fetch` handler. The
+ * Framework owns the REST endpoint, response streaming, and the Lambda entry
+ * that bridges its streaming runtime to this handler.
+ */
+const handler = createMcpHandler(createFactory(logger), {
+  onerror: (error) => logger.error(`MCP serverless handler error: ${error}`),
+});
+
+export default handler;


### PR DESCRIPTION
## Summary

Replaces the Docker/Lambda-Web-Adapter scaffold with the Serverless Framework v4 **native `mcp:` property**, so the Framework owns the REST endpoint, response streaming, packaging, and the Lambda entry that bridges its streaming runtime to the SDK's web-standard `fetch` handler.

## Changes

- **`src/factory.ts`** — extracts the shared `McpServer` factory (`createFactory(logger)`), reused by the stdio, HTTP, and Lambda entries (the v2 SDK is factory-based).
- **`src/serverless.ts`** — new Lambda entry that default-exports the object `createMcpHandler()` returns (the module contract `mcp.servers.<name>.server` requires).
- **`serverless.yml`** (repo root) — native config: `mcp.servers.currency-converter.server: dist/serverless.js`, `runtime: nodejs24.x`, `endpointType: REGIONAL`, `timeout: 30`, `FREE_CURRENCY_API_KEY` from env, and `package.patterns` excluding `.env`/build/test artifacts from the Lambda package.
- **`.github/workflows/deploy-aws.yml`** — rewritten: drops ECR login, image build/push, and Docker entirely; deploys with `npx serverless@4 deploy` using OIDC (`AWS_DEPLOY_ROLE_ARN`) + `SERVERLESS_ACCESS_KEY` + `FREE_CURRENCY_API_KEY`.
- **`.github/workflows/publish.yml`** — adds path filters (`src/**`, `package.json`, `pnpm-lock.yaml`, `.releaserc.json`, workflow) so infrastructure-only pushes don't trigger npm releases.
- **Docs** — README "Deploy to AWS (Serverless Framework)" section and AGENTS.md architecture/gotcha updates.

## Deleted (removed from scaffold, untracked so not in this PR)

The old `serverless/Dockerfile`, `serverless/serverless.yml`, and root `.dockerignore` (Lambda Web Adapter approach) are no longer referenced. They remain as untracked local leftovers and can be deleted manually.

## Notes

- Endpoint is **public** (no `authorizer` / `oauthDiscovery`), served at `/<stage>/currency-converter/mcp`.
- Verified: `pnpm build` + `pnpm test` pass (14/14), and `dist/serverless.js` default-exports a `fetch` handler.

## Requires before deploy runs

- serverless.com access key → `SERVERLESS_ACCESS_KEY` secret
- OIDC IAM role for GitHub Actions → `AWS_DEPLOY_ROLE_ARN` secret
- freecurrencyapi.com key → `FREE_CURRENCY_API_KEY` secret (already present)