### PR TITLE
chore: re-add changelog plugins and backfill CHANGELOG.md

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -9,7 +9,9 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
     "@semantic-release/npm",
+    "@semantic-release/git",
     [
       "@semantic-release/github",
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,44 @@
+# [3.2.0-next.1](https://github.com/dilumdarshana/mcp-currency-converter/compare/v3.1.0...v3.2.0-next.1) (2026-08-17)
+
+
+### Features
+
+* add get-exchange-rate, convert-batch, compare-rates tools ([#11](https://github.com/dilumdarshana/mcp-currency-converter/issues/11)) ([2034c4f](https://github.com/dilumdarshana/mcp-currency-converter/commit/2034c4fff28eb6371291462682489b9adaf71c96))
+
+# [3.1.0](https://github.com/dilumdarshana/mcp-currency-converter/compare/v3.0.0...v3.1.0) (2026-08-12)
+
+
+### Bug Fixes
+
+* **logger:** fall back to console output when home dir is not writable ([73f9b2b](https://github.com/dilumdarshana/mcp-currency-converter/commit/73f9b2b5ca874f90f159e9390265acd2eb2611e0))
+* **serverless:** shim require in esbuild ESM bundle for dotenv ([6435600](https://github.com/dilumdarshana/mcp-currency-converter/commit/64356000205104392a08eb5e5367bb52b2485b30))
+* shrink AWS Lambda package by esbuild-bundling the serverless entry ([fc91fe2](https://github.com/dilumdarshana/mcp-currency-converter/commit/fc91fe26fd8e798f9906f9423f195359fd69000a))
+
+
+### Features
+
+* deploy MCP server to AWS Lambda via Serverless Framework v4 native mcp: property ([962ab41](https://github.com/dilumdarshana/mcp-currency-converter/commit/962ab4178b3e451c512f62ee8469c11f9f10b15a))
+
+# [3.0.0](https://github.com/dilumdarshana/mcp-currency-converter/compare/v2.0.0...v3.0.0) (2026-08-12)
+
+
+* feat!: migrate to MCP SDK v2 (stateless protocol, ESM-only) ([e2ee92c](https://github.com/dilumdarshana/mcp-currency-converter/commit/e2ee92c65825694b616fa9259502835e90a76248))
+
+
+### BREAKING CHANGES
+
+* replace @modelcontextprotocol/sdk v1 with @modelcontextprotocol/server and @modelcontextprotocol/node v2. New stateless 2026-07-28 protocol: no initialize handshake, no Mcp-Session-Id, SSE transport removed. ESM-only (type: module). stdio is now the default transport.
+
+# [3.0.0-next.1](https://github.com/dilumdarshana/mcp-currency-converter/compare/v2.0.0...v3.0.0-next.1) (2026-08-12)
+
+
+* feat!: migrate to MCP SDK v2 (stateless protocol, ESM-only) ([e2ee92c](https://github.com/dilumdarshana/mcp-currency-converter/commit/e2ee92c65825694b616fa9259502835e90a76248))
+
+
+### BREAKING CHANGES
+
+* replace @modelcontextprotocol/sdk v1 with @modelcontextprotocol/server and @modelcontextprotocol/node v2. New stateless 2026-07-28 protocol: no initialize handshake, no Mcp-Session-Id, SSE transport removed. ESM-only (type: module). stdio is now the default transport.
+
 # [2.0.0](https://github.com/dilumdarshana/mcp-currency-converter/compare/v1.1.0...v2.0.0) (2026-06-17)
 
 


### PR DESCRIPTION
Restores auto-generated changelog releases and backfills the missing entries.

## Changes
- **`.releaserc.json`** — re-add `@semantic-release/changelog` + `@semantic-release/git` plugins (both already in devDependencies; used historically, see the `chore(release): x.x.x [skip ci]` commits). Future releases will auto-update `CHANGELOG.md` and commit it back.
- **`CHANGELOG.md`** — backfill entries missing since the plugins were removed: `v3.0.0`, `v3.1.0`, `v3.0.0-next.1`, `v3.2.0-next.1`.

After this merges to `next` and then to `master`, the `master` release (v3.2.0) will generate its changelog entry automatically.