### PR TITLE
release: merge next into master (merge commit) to trigger v3.2.0

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -9,7 +9,9 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
     "@semantic-release/npm",
+    "@semantic-release/git",
     [
       "@semantic-release/github",
       {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ pnpm inspector-http    # build + start http server on :3000 + launch MCP Inspect
 - **MCP SDK v2 `^2.0.0`**: Uses `@modelcontextprotocol/server` (`McpServer`, `createMcpHandler`) + `@modelcontextprotocol/node` (`toNodeHandler`) — NOT the deprecated `@modelcontextprotocol/sdk`
 - **Factory-based**: `serveStdio(factory)` / `createMcpHandler(factory)` build a fresh `McpServer` per request (stateless — no initialize handshake, no `Mcp-Session-Id`). The factory lives in `src/factory.ts` (`createFactory(logger)`) and is shared by stdio, HTTP, and Lambda entries.
 - **3 transports**: `TRANSPORT=stdio` (default when unset), `http`, and the Serverless Framework v4 Lambda entry (`src/serverless.ts`)
-- **1 tool**: `convert-currency` — `z.object({ fromCurrency, toCurrency, amount, date? })`
+- **4 tools**: `convert-currency` (`z.object({ fromCurrency, toCurrency, amount, date? })`), `get-exchange-rate` (`{ fromCurrency, toCurrency, date? }`), `convert-batch` (`{ fromCurrency, amount, toCurrencies, date? }` — `toCurrencies` is a comma-separated string like `"EUR, GBP"`), `compare-rates` (`{ fromCurrency, toCurrency, dates }` — `dates` is a comma-separated string like `"10-08-2025, 11-08-2025"`)
 - **1 resource**: `list-currencies`
 - **1 prompt**: `currency-conversion-prompt`
 - **API**: https://freecurrencyapi.com (requires key)
@@ -46,6 +46,7 @@ pnpm inspector-http    # build + start http server on :3000 + launch MCP Inspect
 - **Logger in Lambda**: `src/utils/logger.ts` writes to `~/.mcp/logs`; in Lambda `$HOME` doesn't exist and `mkdirSync` throws `ENOENT`. The constructor catches this and falls back to `process.stdout`/`process.stderr` (→ CloudWatch). Don't remove the try/catch.
 - **Logger stream types**: `logStream`/`errorStream` are typed `Writable` (from `node:stream`) because they can be either `fs.WriteStream` or `process.stdout` — TS 6.0 rejects the comparison otherwise.
 - **Deploy region drift**: if the workflow's `AWS_REGION` differs from the `serverless.yml` default, CI creates a **second stack in another region** instead of updating the existing one. Keep both pinned to `us-west-2`.
+- **Rate caching**: `src/utils/currencyApi.ts` caches exchange rates in a module-level `Map` for 5 minutes (key = base:currencies:date). Tests must call `clearCache()` in `beforeEach` or a cached response leaks across tests. `parseDate` (DD-MM-YYYY etc.) lives in `src/utils/date.ts`; locale formatting (`formatAmount`/`formatRate`) in `src/utils/format.ts`.
 
 ## Tests
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,44 @@
+# [3.2.0-next.1](https://github.com/dilumdarshana/mcp-currency-converter/compare/v3.1.0...v3.2.0-next.1) (2026-08-17)
+
+
+### Features
+
+* add get-exchange-rate, convert-batch, compare-rates tools ([#11](https://github.com/dilumdarshana/mcp-currency-converter/issues/11)) ([2034c4f](https://github.com/dilumdarshana/mcp-currency-converter/commit/2034c4fff28eb6371291462682489b9adaf71c96))
+
+# [3.1.0](https://github.com/dilumdarshana/mcp-currency-converter/compare/v3.0.0...v3.1.0) (2026-08-12)
+
+
+### Bug Fixes
+
+* **logger:** fall back to console output when home dir is not writable ([73f9b2b](https://github.com/dilumdarshana/mcp-currency-converter/commit/73f9b2b5ca874f90f159e9390265acd2eb2611e0))
+* **serverless:** shim require in esbuild ESM bundle for dotenv ([6435600](https://github.com/dilumdarshana/mcp-currency-converter/commit/64356000205104392a08eb5e5367bb52b2485b30))
+* shrink AWS Lambda package by esbuild-bundling the serverless entry ([fc91fe2](https://github.com/dilumdarshana/mcp-currency-converter/commit/fc91fe26fd8e798f9906f9423f195359fd69000a))
+
+
+### Features
+
+* deploy MCP server to AWS Lambda via Serverless Framework v4 native mcp: property ([962ab41](https://github.com/dilumdarshana/mcp-currency-converter/commit/962ab4178b3e451c512f62ee8469c11f9f10b15a))
+
+# [3.0.0](https://github.com/dilumdarshana/mcp-currency-converter/compare/v2.0.0...v3.0.0) (2026-08-12)
+
+
+* feat!: migrate to MCP SDK v2 (stateless protocol, ESM-only) ([e2ee92c](https://github.com/dilumdarshana/mcp-currency-converter/commit/e2ee92c65825694b616fa9259502835e90a76248))
+
+
+### BREAKING CHANGES
+
+* replace @modelcontextprotocol/sdk v1 with @modelcontextprotocol/server and @modelcontextprotocol/node v2. New stateless 2026-07-28 protocol: no initialize handshake, no Mcp-Session-Id, SSE transport removed. ESM-only (type: module). stdio is now the default transport.
+
+# [3.0.0-next.1](https://github.com/dilumdarshana/mcp-currency-converter/compare/v2.0.0...v3.0.0-next.1) (2026-08-12)
+
+
+* feat!: migrate to MCP SDK v2 (stateless protocol, ESM-only) ([e2ee92c](https://github.com/dilumdarshana/mcp-currency-converter/commit/e2ee92c65825694b616fa9259502835e90a76248))
+
+
+### BREAKING CHANGES
+
+* replace @modelcontextprotocol/sdk v1 with @modelcontextprotocol/server and @modelcontextprotocol/node v2. New stateless 2026-07-28 protocol: no initialize handshake, no Mcp-Session-Id, SSE transport removed. ESM-only (type: module). stdio is now the default transport.
+
 # [2.0.0](https://github.com/dilumdarshana/mcp-currency-converter/compare/v1.1.0...v2.0.0) (2026-06-17)
 
 

--- a/README.md
+++ b/README.md
@@ -9,20 +9,63 @@ pnpm add @alcorme/mcp-currency-converter
 ## Features
 
 - **MCP-compliant server** using `@modelcontextprotocol/server` v2 (stateless, no session handshake)
-- **Transport Support**: Stdio and Streamable HTTP (stateless)
+- **Transport Support**: Stdio, Streamable HTTP, and managed AWS Lambda (Serverless Framework v4)
+- **4 Tools**:
+  - `convert-currency` — convert an amount between two currencies
+  - `get-exchange-rate` — fetch the raw exchange rate for a currency pair
+  - `convert-batch` — convert an amount to multiple currencies in one call
+  - `compare-rates` — compare a currency pair across multiple dates
 - **Currency Conversion**: Real-time exchange rates or historical exchange rates
+- **Rate Caching**: Exchange rates cached in-memory (5-minute TTL) to reduce API calls
+- **Locale-aware Formatting**: `Intl.NumberFormat` for amounts and rates
 - **Resource Management**: List supported currencies via resources
 - **Prompt Capability**: Interactive prompts for dynamic input
 - **Unit Testing**: Vitest powered unit testing
 - **Type Safety**: Built with TypeScript
 - **Package Management**: Uses `pnpm` for efficient dependency management
-- **Authentication for http transport**: TBD
 
 ---
 
 ## Example queries
 - Convert 1 USD to EUR
 - Convert 1 USD to EUR on 12 August 2025
+- What is the exchange rate for USD to EUR?
+- Convert 100 USD to EUR, GBP, and JPY
+- Compare USD to EUR rates for 10 Aug, 11 Aug, and 12 Aug 2025
+
+## Tool usage
+
+Each tool takes a JSON object. `date` is optional — when omitted, empty, or whitespace, the latest rate is used. Currency codes are case-insensitive (normalized to uppercase).
+
+### convert-currency
+
+```json
+{ "fromCurrency": "USD", "toCurrency": "EUR", "amount": 100 }
+{ "fromCurrency": "USD", "toCurrency": "EUR", "amount": 100, "date": "12-08-2025" }
+```
+
+### get-exchange-rate
+
+```json
+{ "fromCurrency": "USD", "toCurrency": "EUR" }
+{ "fromCurrency": "USD", "toCurrency": "EUR", "date": "12-08-2025" }
+```
+
+### convert-batch
+
+`toCurrencies` is a comma-separated string:
+
+```json
+{ "fromCurrency": "USD", "amount": 100, "toCurrencies": "EUR, GBP, JPY" }
+```
+
+### compare-rates
+
+`dates` is a comma-separated string:
+
+```json
+{ "fromCurrency": "USD", "toCurrency": "EUR", "dates": "10-08-2025, 11-08-2025, 12-08-2025" }
+```
 
 
 ## Prerequisites

--- a/src/tools/compareRates.test.ts
+++ b/src/tools/compareRates.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { compareRates } from './compareRates.js';
+import { clearCache } from '../utils/currencyApi.js';
+import { Logger } from '../utils/logger.js';
+
+const mockLogger: Logger = {
+  info: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+  close: vi.fn(),
+} as unknown as Logger;
+
+describe('compareRates', () => {
+  beforeEach(() => {
+    process.env.FREE_CURRENCY_API_KEY = 'fake-api-key';
+    global.fetch = vi.fn();
+    clearCache();
+  });
+
+  it('should compare rates across multiple dates', async () => {
+    (global.fetch as any)
+      .mockResolvedValueOnce({
+        json: async () => ({ data: { '2025-08-12': { EUR: 0.85 } } }),
+      })
+      .mockResolvedValueOnce({
+        json: async () => ({ data: { '2025-08-13': { EUR: 0.86 } } }),
+      });
+
+    const result = await compareRates(
+      { fromCurrency: 'USD', toCurrency: 'EUR', dates: '12-08-2025, 13-08-2025' },
+      mockLogger
+    );
+
+    const text = (result.content[0] as { type: 'text'; text: string }).text;
+    expect(text).toContain('across 2 dates');
+    expect(text).toContain('12 August 2025');
+    expect(text).toContain('13 August 2025');
+  });
+
+  it('should handle an invalid exchange rate for a date', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      json: async () => ({ data: { '2025-08-12': {} } }),
+    });
+
+    const result = await compareRates(
+      { fromCurrency: 'USD', toCurrency: 'EUR', dates: '12-08-2025' },
+      mockLogger
+    );
+
+    expect((result.content[0] as { type: 'text'; text: string }).text).toContain('Error: Invalid exchange rate for 12-08-2025');
+    expect(mockLogger.error).toHaveBeenCalled();
+  });
+});

--- a/src/tools/compareRates.ts
+++ b/src/tools/compareRates.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod';
+import type { CallToolResult } from '@modelcontextprotocol/server';
+import { Logger } from '../utils/logger.js';
+import { formatResponse } from '../utils/mcpResponse.js';
+import { fetchRates } from '../utils/currencyApi.js';
+import { parseDate } from '../utils/date.js';
+import { formatRate } from '../utils/format.js';
+
+export const compareRatesSchema = z.object({
+  fromCurrency: z.string().describe('The base currency (e.g., USD)'),
+  toCurrency: z.string().describe('The quote currency (e.g., EUR)'),
+  dates: z
+    .string()
+    .min(1)
+    .describe('Comma-separated dates to compare in DD-MM-YYYY format (e.g., "12-08-2025, 13-08-2025")'),
+});
+
+export type CompareRatesInput = z.infer<typeof compareRatesSchema>;
+
+/**
+ * Compares the exchange rate between two currencies across multiple dates.
+ * Each date is a separate historical API call (cached per date).
+ *
+ * @param input The tool input (base/quote currency and the dates to compare)
+ * @param logger Logger instance for logging messages and errors
+ * @returns A CallToolResult containing the rates per date
+ */
+export async function compareRates(
+  { fromCurrency, toCurrency, dates }: CompareRatesInput,
+  logger: Logger,
+): Promise<CallToolResult> {
+  try {
+    const from = fromCurrency.toUpperCase();
+    const to = toCurrency.toUpperCase();
+    const dateList = dates
+      .split(',')
+      .map((d) => d.trim())
+      .filter((d) => d.length > 0);
+    const rates: Array<{ date: string; rate: string }> = [];
+
+    for (const date of dateList) {
+      const { formattedDate, readableDate } = parseDate(date);
+      const dateRates = await fetchRates(from, [to], formattedDate);
+      const rate = dateRates[to];
+
+      if (!rate) {
+        throw new Error(`Invalid exchange rate for ${date}`);
+      }
+
+      rates.push({ date: readableDate ?? date, rate: formatRate(rate) });
+    }
+
+    return formatResponse({
+      message: `Exchange rates from ${from} to ${to} across ${rates.length} dates`,
+      rates,
+    });
+  } catch (error) {
+    logger.error(`Error comparing rates: ${error}`);
+    return formatResponse({ error: `Error: ${error}` });
+  }
+}

--- a/src/tools/convertBatch.test.ts
+++ b/src/tools/convertBatch.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { convertBatch } from './convertBatch.js';
+import { clearCache } from '../utils/currencyApi.js';
+import { Logger } from '../utils/logger.js';
+
+const mockLogger: Logger = {
+  info: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+  close: vi.fn(),
+} as unknown as Logger;
+
+describe('convertBatch', () => {
+  beforeEach(() => {
+    process.env.FREE_CURRENCY_API_KEY = 'fake-api-key';
+    global.fetch = vi.fn();
+    clearCache();
+  });
+
+  it('should convert to multiple currencies', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      json: async () => ({ data: { EUR: 0.85, GBP: 0.75 } }),
+    });
+
+    const result = await convertBatch(
+      { fromCurrency: 'USD', amount: 100, toCurrencies: 'EUR, GBP' },
+      mockLogger
+    );
+
+    const text = (result.content[0] as { type: 'text'; text: string }).text;
+    expect(text).toContain('Converted 100 USD to 2 currencies on latest');
+    expect(text).toContain('EUR');
+    expect(text).toContain('GBP');
+  });
+
+  it('should handle an invalid exchange rate for a currency', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      json: async () => ({ data: { EUR: 0.85 } }),
+    });
+
+    const result = await convertBatch(
+      { fromCurrency: 'USD', amount: 100, toCurrencies: 'EUR, GBP' },
+      mockLogger
+    );
+
+    expect((result.content[0] as { type: 'text'; text: string }).text).toContain('Error: Invalid exchange rate for GBP');
+    expect(mockLogger.error).toHaveBeenCalled();
+  });
+
+  it('should normalize lowercase codes and reject unsupported ones', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      json: async () => ({ data: { EUR: 0.85 } }),
+    });
+
+    const result = await convertBatch(
+      { fromCurrency: 'usd', amount: 100, toCurrencies: 'eur, XXX' },
+      mockLogger
+    );
+
+    expect((result.content[0] as { type: 'text'; text: string }).text).toContain('Error: Unsupported currency code(s): XXX');
+    expect(mockLogger.error).toHaveBeenCalled();
+  });
+});

--- a/src/tools/convertBatch.ts
+++ b/src/tools/convertBatch.ts
@@ -1,0 +1,71 @@
+import { z } from 'zod';
+import type { CallToolResult } from '@modelcontextprotocol/server';
+import { Logger } from '../utils/logger.js';
+import { formatResponse } from '../utils/mcpResponse.js';
+import { fetchRates } from '../utils/currencyApi.js';
+import { parseDate } from '../utils/date.js';
+import { formatAmount, formatRate } from '../utils/format.js';
+import { SUPPORTED_CURRENCIES } from '../utils/constants.js';
+
+export const convertBatchSchema = z.object({
+  fromCurrency: z.string().describe('The currency to convert from (e.g., USD)'),
+  amount: z.number().positive().describe('The amount to convert'),
+  toCurrencies: z
+    .string()
+    .min(1)
+    .describe('Comma-separated currencies to convert to (e.g., "EUR, GBP")'),
+  date: z.string().optional().describe('The historical date for conversion in DD-MM-YYYY format'),
+});
+
+export type ConvertBatchInput = z.infer<typeof convertBatchSchema>;
+
+/**
+ * Converts an amount from one currency to multiple target currencies in a
+ * single call, using one exchange-rate fetch.
+ *
+ * @param input The tool input (source currency, amount, target currencies, optional date)
+ * @param logger Logger instance for logging messages and errors
+ * @returns A CallToolResult containing the conversions
+ */
+export async function convertBatch(
+  { fromCurrency, amount, toCurrencies, date }: ConvertBatchInput,
+  logger: Logger,
+): Promise<CallToolResult> {
+  try {
+    const from = fromCurrency.toUpperCase();
+    const targets = toCurrencies
+      .split(',')
+      .map((c) => c.trim().toUpperCase())
+      .filter((c) => c.length > 0);
+
+    const invalid = targets.filter(
+      (c) => !(SUPPORTED_CURRENCIES as readonly string[]).includes(c),
+    );
+    if (invalid.length > 0) {
+      throw new Error(`Unsupported currency code(s): ${invalid.join(', ')}`);
+    }
+
+    const { formattedDate, readableDate } = parseDate(date);
+    const rates = await fetchRates(from, targets, formattedDate);
+
+    const conversions = targets.map((toCurrency) => {
+      const rate = rates[toCurrency];
+      if (!rate) {
+        throw new Error(`Invalid exchange rate for ${toCurrency}`);
+      }
+      return {
+        toCurrency,
+        rate: formatRate(rate),
+        convertedAmount: formatAmount(amount * rate, toCurrency),
+      };
+    });
+
+    return formatResponse({
+      message: `Converted ${amount} ${from} to ${conversions.length} currencies on ${readableDate || 'latest'}`,
+      conversions,
+    });
+  } catch (error) {
+    logger.error(`Error converting batch: ${error}`);
+    return formatResponse({ error: `Error: ${error}` });
+  }
+}

--- a/src/tools/convertCurrency.test.ts
+++ b/src/tools/convertCurrency.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { convertCurrency } from './convertCurrency.js';
+import { clearCache } from '../utils/currencyApi.js';
 import { Logger } from '../utils/logger.js';
 
 const mockLogger: Logger = {
@@ -17,6 +18,9 @@ describe('convertCurrency', () => {
 
     // Mock the fetch function
     global.fetch = vi.fn();
+
+    // Clear the shared rate cache between tests
+    clearCache();
   });
 
   it('should convert currency successfully without date', async () => {
@@ -53,12 +57,28 @@ describe('convertCurrency', () => {
     expect(mockLogger.info).toHaveBeenCalledWith('Converting 100 USD to EUR...');
   });
 
+  it('should default to latest rates when the date is empty', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      json: async () => ({ data: { EUR: 0.85 } }),
+    });
+
+    const result = await convertCurrency(
+      { fromCurrency: 'USD', toCurrency: 'EUR', amount: 100, date: '' },
+      mockLogger
+    );
+
+    expect((result.content[0] as { type: 'text'; text: string }).text).toContain('Converted 100 USD to EUR on latest: 85 EUR');
+  });
+
   it('should handle missing API key', async () => {
     delete process.env.FREE_CURRENCY_API_KEY;
 
-    await expect(
-      convertCurrency({ fromCurrency: 'USD', toCurrency: 'EUR', amount: 100 }, mockLogger)
-    ).rejects.toThrow('Missing FREE_CURRENCY_KEY');
+    const result = await convertCurrency(
+      { fromCurrency: 'USD', toCurrency: 'EUR', amount: 100 },
+      mockLogger
+    );
+
+    expect((result.content[0] as { type: 'text'; text: string }).text).toContain('Error: Missing FREE_CURRENCY_KEY');
   });
 
   it('should handle invalid exchange rate', async () => {

--- a/src/tools/convertCurrency.ts
+++ b/src/tools/convertCurrency.ts
@@ -5,14 +5,10 @@
  */
 import { z } from 'zod';
 import type { CallToolResult } from '@modelcontextprotocol/server';
-import dayjs from 'dayjs';
-import customParseFormat from 'dayjs/plugin/customParseFormat.js';
 import { Logger } from '../utils/logger.js';
-import { CurrencyApiResponse } from '../types.js';
 import { formatResponse } from '../utils/mcpResponse.js';
-import { CURRENCY_ENDPOINT_BASE } from '../utils/constants.js';
-
-dayjs.extend(customParseFormat);
+import { fetchRates } from '../utils/currencyApi.js';
+import { parseDate } from '../utils/date.js';
 
 // Define the schema for the convert currency tool input
 export const convertCurrencySchema = z.object({
@@ -39,50 +35,17 @@ export async function convertCurrency(
   { fromCurrency, toCurrency, amount, date }: ConvertCurrencyInput,
   logger: Logger,
 ): Promise<CallToolResult> {
-  // Retrieve the API key for the Free Currency API from environment variables
-  const currencyFinderKey = process.env.FREE_CURRENCY_API_KEY;
-  if (!currencyFinderKey) throw new Error('Missing FREE_CURRENCY_KEY');
-
   try {
-    // Fetch the latest exchange rate for the specified currencies
-    // Normalize the date format to YYYY-MM-DD if a date is provided
-    let formattedDate: string | undefined;
-    let readableDate: string | undefined;
-    if (date) {
-      const formats = ['DD-MM-YYYY', 'YYYY-MM-DD', 'MMMM D, YYYY', 'MM/DD/YYYY', 'D MMMM YYYY'];
-      const parsedDate = dayjs(date, formats, true);
-
-      if (!parsedDate.isValid()) {
-        throw new Error('Invalid date format. Please provide a valid date.');
-      }
-      formattedDate = parsedDate.format('YYYY-MM-DD');
-      readableDate = parsedDate.format('D MMMM YYYY'); // Format to a human-readable date
-    }
-
-    // Here have two endpoint to decide
-    const endpoint = formattedDate
-      ? `${CURRENCY_ENDPOINT_BASE}/historical?apikey=${currencyFinderKey}&base_currency=${fromCurrency}&currencies=${toCurrency}&date=${formattedDate}`
-      : `${CURRENCY_ENDPOINT_BASE}/latest?apikey=${currencyFinderKey}&base_currency=${fromCurrency}&currencies=${toCurrency}`;
-
-    const response = await fetch(endpoint);
+    const from = fromCurrency.toUpperCase();
+    const to = toCurrency.toUpperCase();
+    const { formattedDate, readableDate } = parseDate(date);
 
     // Log the conversion request for debugging purposes
-    logger.info(`Converting ${amount} ${fromCurrency} to ${toCurrency}...`);
+    logger.info(`Converting ${amount} ${from} to ${to}...`);
 
-    // Parse the response data and extract the exchange rate
-    const data = (await response.json()) as CurrencyApiResponse;
-
-    // Extract the exchange rate based on the response structure
-    let exchangeRate: number | undefined;
-
-    if (formattedDate) {
-      // Historical response structure
-      const historicalData = data.data[formattedDate] as Record<string, number>;
-      exchangeRate = historicalData?.[toCurrency];
-    } else {
-      // Latest response structure
-      exchangeRate = (data as any)?.data?.[toCurrency] as number;
-    }
+    // Fetch the exchange rate for the specified currencies (cached by the API client)
+    const rates = await fetchRates(from, [to], formattedDate);
+    const exchangeRate = rates[to];
 
     // Throw an error if the exchange rate is invalid or missing
     if (!exchangeRate) {
@@ -94,7 +57,7 @@ export async function convertCurrency(
 
     // Use the formatResponse utility to standardize the response format
     return formatResponse({
-      message: `Converted ${amount} ${fromCurrency} to ${toCurrency} on ${readableDate || 'latest'}: ${convertedAmount} ${toCurrency}`,
+      message: `Converted ${amount} ${from} to ${to} on ${readableDate || 'latest'}: ${convertedAmount} ${to}`,
     });
   } catch (error) {
     // Log the error for debugging purposes

--- a/src/tools/getExchangeRate.test.ts
+++ b/src/tools/getExchangeRate.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getExchangeRate } from './getExchangeRate.js';
+import { clearCache } from '../utils/currencyApi.js';
+import { Logger } from '../utils/logger.js';
+
+const mockLogger: Logger = {
+  info: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+  close: vi.fn(),
+} as unknown as Logger;
+
+describe('getExchangeRate', () => {
+  beforeEach(() => {
+    process.env.FREE_CURRENCY_API_KEY = 'fake-api-key';
+    global.fetch = vi.fn();
+    clearCache();
+  });
+
+  it('should return the exchange rate without a date', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      json: async () => ({ data: { EUR: 0.85 } }),
+    });
+
+    const result = await getExchangeRate(
+      { fromCurrency: 'USD', toCurrency: 'EUR' },
+      mockLogger
+    );
+
+    const text = (result.content[0] as { type: 'text'; text: string }).text;
+    expect(text).toContain('Exchange rate from USD to EUR on latest');
+    expect(text).toContain('0.85');
+  });
+
+  it('should return the exchange rate with a date', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      json: async () => ({ data: { '2025-08-12': { EUR: 0.85 } } }),
+    });
+
+    const result = await getExchangeRate(
+      { fromCurrency: 'USD', toCurrency: 'EUR', date: '12-08-2025' },
+      mockLogger
+    );
+
+    const text = (result.content[0] as { type: 'text'; text: string }).text;
+    expect(text).toContain('on 12 August 2025');
+  });
+
+  it('should default to latest rates when the date is empty or whitespace', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      json: async () => ({ data: { EUR: 0.85 } }),
+    });
+
+    const result = await getExchangeRate(
+      { fromCurrency: 'USD', toCurrency: 'EUR', date: '   ' },
+      mockLogger
+    );
+
+    const text = (result.content[0] as { type: 'text'; text: string }).text;
+    expect(text).toContain('on latest');
+    expect(text).toContain('0.85');
+  });
+
+  it('should normalize lowercase currency codes to uppercase', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      json: async () => ({ data: { EUR: 0.85 } }),
+    });
+
+    const result = await getExchangeRate(
+      { fromCurrency: 'usd', toCurrency: 'eur', date: '' },
+      mockLogger
+    );
+
+    const text = (result.content[0] as { type: 'text'; text: string }).text;
+    expect(text).toContain('Exchange rate from USD to EUR on latest');
+    expect(text).toContain('0.85');
+    const url = (global.fetch as any).mock.calls[0][0];
+    expect(url).toContain('base_currency=USD');
+    expect(url).toContain('currencies=EUR');
+  });
+
+  it('should handle an invalid exchange rate', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      json: async () => ({ data: {} }),
+    });
+
+    const result = await getExchangeRate(
+      { fromCurrency: 'USD', toCurrency: 'EUR' },
+      mockLogger
+    );
+
+    expect((result.content[0] as { type: 'text'; text: string }).text).toContain('Error: Invalid exchange rate');
+    expect(mockLogger.error).toHaveBeenCalled();
+  });
+});

--- a/src/tools/getExchangeRate.ts
+++ b/src/tools/getExchangeRate.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+import type { CallToolResult } from '@modelcontextprotocol/server';
+import { Logger } from '../utils/logger.js';
+import { formatResponse } from '../utils/mcpResponse.js';
+import { fetchRates } from '../utils/currencyApi.js';
+import { parseDate } from '../utils/date.js';
+import { formatRate } from '../utils/format.js';
+
+export const getExchangeRateSchema = z.object({
+  fromCurrency: z.string().describe('The base currency (e.g., USD)'),
+  toCurrency: z.string().describe('The quote currency (e.g., EUR)'),
+  date: z.string().optional().describe('The historical date for the rate in DD-MM-YYYY format'),
+});
+
+export type GetExchangeRateInput = z.infer<typeof getExchangeRateSchema>;
+
+/**
+ * Returns the exchange rate between two currencies, for the latest date or a
+ * specific historical date.
+ *
+ * @param input The tool input (base/quote currency and optional date)
+ * @param logger Logger instance for logging messages and errors
+ * @returns A CallToolResult containing the exchange rate
+ */
+export async function getExchangeRate(
+  { fromCurrency, toCurrency, date }: GetExchangeRateInput,
+  logger: Logger,
+): Promise<CallToolResult> {
+  try {
+    const from = fromCurrency.toUpperCase();
+    const to = toCurrency.toUpperCase();
+    const { formattedDate, readableDate } = parseDate(date);
+    const rates = await fetchRates(from, [to], formattedDate);
+    const rate = rates[to];
+
+    if (!rate) {
+      throw new Error('Invalid exchange rate');
+    }
+
+    return formatResponse({
+      message: `Exchange rate from ${from} to ${to} on ${readableDate || 'latest'}: ${formatRate(rate)}`,
+      fromCurrency: from,
+      toCurrency: to,
+      rate: formatRate(rate),
+      date: readableDate || 'latest',
+    });
+  } catch (error) {
+    logger.error(`Error fetching exchange rate: ${error}`);
+    return formatResponse({ error: `Error: ${error}` });
+  }
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -14,3 +14,11 @@ export const PACKAGE_NAME = '@alcorme/mcp-currency-converter';
 
 // Base path of the currency conversion API
 export const CURRENCY_ENDPOINT_BASE = 'https://api.freecurrencyapi.com/v1';
+
+// Currencies supported by the Free Currency API (ISO 4217 codes)
+export const SUPPORTED_CURRENCIES = [
+  'AUD', 'BGN', 'BRL', 'CAD', 'CHF', 'CNY', 'CZK', 'DKK', 'EUR', 'GBP',
+  'HKD', 'HRK', 'HUF', 'IDR', 'ILS', 'INR', 'ISK', 'JPY', 'KRW', 'MXN',
+  'MYR', 'NOK', 'NZD', 'PHP', 'PLN', 'RON', 'RUB', 'SEK', 'SGD', 'THB',
+  'TRY', 'USD', 'ZAR',
+] as const;

--- a/src/utils/currencyApi.test.ts
+++ b/src/utils/currencyApi.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fetchRates, clearCache } from './currencyApi.js';
+
+describe('currencyApi', () => {
+  beforeEach(() => {
+    process.env.FREE_CURRENCY_API_KEY = 'fake-api-key';
+    global.fetch = vi.fn();
+    clearCache();
+  });
+
+  it('should fetch latest rates', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      json: async () => ({ data: { EUR: 0.85, GBP: 0.75 } }),
+    });
+
+    const rates = await fetchRates('USD', ['EUR', 'GBP']);
+
+    expect(rates).toEqual({ EUR: 0.85, GBP: 0.75 });
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('should fetch historical rates', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      json: async () => ({ data: { '2025-08-12': { EUR: 0.85 } } }),
+    });
+
+    const rates = await fetchRates('USD', ['EUR'], '2025-08-12');
+
+    expect(rates).toEqual({ EUR: 0.85 });
+  });
+
+  it('should cache repeated calls within the TTL', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      json: async () => ({ data: { EUR: 0.85 } }),
+    });
+
+    const first = await fetchRates('USD', ['EUR']);
+    const second = await fetchRates('USD', ['EUR']);
+
+    expect(first).toEqual(second);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('should throw when the API key is missing', async () => {
+    delete process.env.FREE_CURRENCY_API_KEY;
+
+    await expect(fetchRates('USD', ['EUR'])).rejects.toThrow('Missing FREE_CURRENCY_KEY');
+  });
+});

--- a/src/utils/currencyApi.ts
+++ b/src/utils/currencyApi.ts
@@ -1,0 +1,69 @@
+import { CURRENCY_ENDPOINT_BASE } from './constants.js';
+import { CurrencyApiResponse } from '../types.js';
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface CacheEntry {
+  rates: Record<string, number>;
+  expiresAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+/**
+ * Returns the Free Currency API key from the environment.
+ * @throws When the key is missing
+ */
+export function getApiKey(): string {
+  const key = process.env.FREE_CURRENCY_API_KEY;
+  if (!key) throw new Error('Missing FREE_CURRENCY_KEY');
+  return key;
+}
+
+/**
+ * Fetches exchange rates for a base currency against one or more quote
+ * currencies, for the latest date or a specific historical date. Results are
+ * cached in-memory for CACHE_TTL_MS to avoid redundant API calls.
+ *
+ * @param baseCurrency The base currency code (e.g. USD)
+ * @param currencies The quote currency codes (e.g. ['EUR', 'GBP'])
+ * @param date The historical date in YYYY-MM-DD format, or undefined for latest
+ * @returns A record mapping quote currency codes to exchange rates
+ */
+export async function fetchRates(
+  baseCurrency: string,
+  currencies: string[],
+  date?: string,
+): Promise<Record<string, number>> {
+  const normalizedBase = baseCurrency.toUpperCase();
+  const normalizedCurrencies = currencies.map((c) => c.toUpperCase());
+  const cacheKey = `${normalizedBase}:${[...normalizedCurrencies].sort().join(',')}:${date ?? 'latest'}`;
+  const now = Date.now();
+  const cached = cache.get(cacheKey);
+  if (cached && cached.expiresAt > now) {
+    return cached.rates;
+  }
+
+  const apiKey = getApiKey();
+  const currencyParam = normalizedCurrencies.join(',');
+  const endpoint = date
+    ? `${CURRENCY_ENDPOINT_BASE}/historical?apikey=${apiKey}&base_currency=${normalizedBase}&currencies=${currencyParam}&date=${date}`
+    : `${CURRENCY_ENDPOINT_BASE}/latest?apikey=${apiKey}&base_currency=${normalizedBase}&currencies=${currencyParam}`;
+
+  const response = await fetch(endpoint);
+  const data = (await response.json()) as CurrencyApiResponse;
+
+  const rates = date
+    ? ((data.data?.[date] as Record<string, number>) ?? {})
+    : ((data.data as Record<string, number>) ?? {});
+
+  cache.set(cacheKey, { rates, expiresAt: now + CACHE_TTL_MS });
+  return rates;
+}
+
+/**
+ * Clears the in-memory rate cache. Primarily used by tests.
+ */
+export function clearCache(): void {
+  cache.clear();
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,33 @@
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat.js';
+
+dayjs.extend(customParseFormat);
+
+const DATE_FORMATS = ['DD-MM-YYYY', 'YYYY-MM-DD', 'MMMM D, YYYY', 'MM/DD/YYYY', 'D MMMM YYYY'];
+
+export interface ParsedDate {
+  formattedDate?: string;
+  readableDate?: string;
+}
+
+/**
+ * Parses a user-supplied date into the API's YYYY-MM-DD format plus a
+ * human-readable label. Empty, whitespace-only, or missing dates default to the
+ * latest available rates (the historical endpoint rejects today's date).
+ *
+ * @param date The date string in a supported format (e.g. DD-MM-YYYY)
+ * @returns The normalized date and a readable label
+ */
+export function parseDate(date?: string | null): ParsedDate {
+  if (!date || date.trim() === '') return {};
+
+  const parsed = dayjs(date, DATE_FORMATS, true);
+  if (!parsed.isValid()) {
+    throw new Error('Invalid date format. Please provide a valid date.');
+  }
+
+  return {
+    formattedDate: parsed.format('YYYY-MM-DD'),
+    readableDate: parsed.format('D MMMM YYYY'),
+  };
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,39 @@
+/**
+ * Locale-aware formatting helpers for currency amounts and exchange rates.
+ */
+
+/**
+ * Formats an amount in the given currency using locale-aware currency
+ * formatting (e.g. €85.00). Falls back to a plain number when the currency
+ * code is not recognized by the runtime.
+ *
+ * @param amount The numeric amount
+ * @param currency The ISO currency code (e.g. EUR)
+ * @returns The formatted amount string
+ */
+export function formatAmount(amount: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(amount);
+  } catch {
+    return `${amount.toFixed(2)} ${currency}`;
+  }
+}
+
+/**
+ * Formats an exchange rate with enough precision to be meaningful (4-6
+ * significant decimal places).
+ *
+ * @param rate The exchange rate
+ * @returns The formatted rate string
+ */
+export function formatRate(rate: number): string {
+  return new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: 4,
+    maximumFractionDigits: 6,
+  }).format(rate);
+}

--- a/src/utils/registrations.test.ts
+++ b/src/utils/registrations.test.ts
@@ -3,6 +3,9 @@ import { McpServer } from '@modelcontextprotocol/server';
 import { Logger } from './logger.js';
 import { registerTools, registerResources, registerPrompts } from './registrations.js';
 import { convertCurrencySchema } from '../tools/convertCurrency.js';
+import { getExchangeRateSchema } from '../tools/getExchangeRate.js';
+import { convertBatchSchema } from '../tools/convertBatch.js';
+import { compareRatesSchema } from '../tools/compareRates.js';
 import { currencyPromptSchema } from '../prompts/currencyPrompt.js';
 
 describe('MCP Server Registrations', () => {
@@ -39,6 +42,57 @@ describe('MCP Server Registrations', () => {
       },
       expect.any(Function)
     );
+
+    expect(mockServer.registerTool).toHaveBeenCalledWith(
+      'get-exchange-rate',
+      {
+        title: 'get-exchange-rate',
+        description: 'Returns the exchange rate between two currencies',
+        inputSchema: getExchangeRateSchema,
+        annotations: {
+          title: 'get-exchange-rate',
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: true,
+        },
+      },
+      expect.any(Function)
+    );
+
+    expect(mockServer.registerTool).toHaveBeenCalledWith(
+      'convert-batch',
+      {
+        title: 'convert-batch',
+        description: 'Converts an amount from one currency to multiple currencies in a single call',
+        inputSchema: convertBatchSchema,
+        annotations: {
+          title: 'convert-batch',
+          readOnlyHint: false,
+          destructiveHint: false,
+          idempotentHint: false,
+          openWorldHint: true,
+        },
+      },
+      expect.any(Function)
+    );
+
+    expect(mockServer.registerTool).toHaveBeenCalledWith(
+      'compare-rates',
+      {
+        title: 'compare-rates',
+        description: 'Compares the exchange rate between two currencies across multiple dates',
+        inputSchema: compareRatesSchema,
+        annotations: {
+          title: 'compare-rates',
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: true,
+        },
+      },
+      expect.any(Function)
+    );
   });
 
   it('should register resources correctly', () => {
@@ -63,7 +117,7 @@ describe('MCP Server Registrations', () => {
       'currency-conversion-prompt',
       {
         description: 'Prompt for currency conversion details',
-        argsSchema: currencyPromptSchema.shape,
+        argsSchema: currencyPromptSchema,
       },
       expect.any(Function)
     );

--- a/src/utils/registrations.ts
+++ b/src/utils/registrations.ts
@@ -1,6 +1,9 @@
 import { McpServer } from '@modelcontextprotocol/server';
 import { Logger } from './logger.js';
 import { convertCurrency, convertCurrencySchema } from '../tools/convertCurrency.js';
+import { getExchangeRate, getExchangeRateSchema } from '../tools/getExchangeRate.js';
+import { convertBatch, convertBatchSchema } from '../tools/convertBatch.js';
+import { compareRates, compareRatesSchema } from '../tools/compareRates.js';
 import { listCurrencies } from '../resources/listCurrencies.js';
 import { currencyPromptSchema, handleCurrencyPrompt } from '../prompts/currencyPrompt.js';
 
@@ -25,6 +28,57 @@ export function registerTools(server: McpServer, logger: Logger) {
       },
     },
     (input) => convertCurrency(input, logger),
+  );
+
+  server.registerTool(
+    'get-exchange-rate',
+    {
+      title: 'get-exchange-rate',
+      description: 'Returns the exchange rate between two currencies',
+      inputSchema: getExchangeRateSchema,
+      annotations: {
+        title: 'get-exchange-rate',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    (input) => getExchangeRate(input, logger),
+  );
+
+  server.registerTool(
+    'convert-batch',
+    {
+      title: 'convert-batch',
+      description: 'Converts an amount from one currency to multiple currencies in a single call',
+      inputSchema: convertBatchSchema,
+      annotations: {
+        title: 'convert-batch',
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+    },
+    (input) => convertBatch(input, logger),
+  );
+
+  server.registerTool(
+    'compare-rates',
+    {
+      title: 'compare-rates',
+      description: 'Compares the exchange rate between two currencies across multiple dates',
+      inputSchema: compareRatesSchema,
+      annotations: {
+        title: 'compare-rates',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    (input) => compareRates(input, logger),
   );
 }
 
@@ -56,7 +110,7 @@ export function registerPrompts(server: McpServer, logger: Logger) {
     'currency-conversion-prompt',
     {
       description: 'Prompt for currency conversion details',
-      argsSchema: currencyPromptSchema.shape,
+      argsSchema: currencyPromptSchema,
     },
     (input) => handleCurrencyPrompt(input, logger),
   );


### PR DESCRIPTION
Re-merges `next` into `master` with a **merge commit** (not squash) so the `feat: add get-exchange-rate, convert-batch, compare-rates tools` commit enters master's history.

The previous promotion (PR #13) was squashed, which flattened the `feat` commit away — semantic-release then found "no relevant changes" and skipped the v3.2.0 release. This merge restores the conventional commit to master's history so semantic-release can release **v3.2.0** as `latest`.

No file content changes (master and next are already identical).